### PR TITLE
"Сворачиваемость" результатов анализа

### DIFF
--- a/app/logic/get_analysis_result.py
+++ b/app/logic/get_analysis_result.py
@@ -38,7 +38,9 @@ def get_analysis_result(repository, yaml_root, synonyms, update_repository='fals
 
         results.append({
             'header': result.header,
-            'body': body
+            'body': body,
+            'ok': result.is_ok(),
+            'errors_num': len(result.results)
         })
 
     os.chdir(cwd)

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -20,6 +20,10 @@ body {
     margin-top:50px;
 }
 
+#results .panel-heading {
+    cursor: pointer;
+}
+
 #results .panel {
     margin: 10px;
 }

--- a/app/static/js/analysis.js
+++ b/app/static/js/analysis.js
@@ -37,7 +37,7 @@ $(function(){
                 $('#results').empty();
 
                 // Sort results such that failed ones come first
-                data.sort(function(r1, r2){
+                data.sort(function byOk(r1, r2){
                     r1 = r1.ok;
                     r2 = r2.ok;
 
@@ -64,6 +64,10 @@ $(function(){
                     var panelHeading = $('<div class="panel-heading">' + result.header + headerErrors + '</div>');
                     var panelBody = $('<div class="panel-body">' + result.body + '</div>');
 
+                    panelHeading.click(onPanelHeadingClick);
+
+                    panelBody.hide();
+
                     panel.append(panelHeading);
                     panel.append(panelBody);
 
@@ -72,6 +76,12 @@ $(function(){
             }
         );
     });
+
+    function onPanelHeadingClick(){
+        var parent = $(this).parent();
+
+        parent.find(".panel-body").toggle();
+    }
 
     // Don't submit the form
     $('#form').submit(function(e){

--- a/app/static/js/analysis.js
+++ b/app/static/js/analysis.js
@@ -30,19 +30,38 @@ $(function(){
         options.synonyms = synonyms;
         options.update_repository = update_repository;
 
-        console.log(options);
-
         $.getJSON(SCRIPT_ROOT + '/api/analysis', 
             options,
             function(data){
                 var data = data.result;
                 $('#results').empty();
 
+                // Sort results such that failed ones come first
+                data.sort(function(r1, r2){
+                    r1 = r1.ok;
+                    r2 = r2.ok;
+
+                    if(r1 && !r2){
+                        return 1;
+                    }
+
+                    if(r2 && !r1){
+                        return -1;
+                    }
+
+                    return 0;
+                });
+
                 data.forEach(function(result){
                     result.body = result.body.replace(/\n+/g, '<br>');
 
-                    var panel = $('<div class="panel panel-default"></div>');
-                    var panelHeading = $('<div class="panel-heading">' + result.header + '</div>');
+                    var panelStyle = result.ok ? 'panel-success' : 'panel-danger';
+
+                    var errorNums = '. ' + result.errors_num + (result.errors_num == 1 ? 'error' : ' errors');
+                    var headerErrors = result.ok ? '' : errorNums;
+
+                    var panel = $('<div class="panel ' + panelStyle + '"></div>');
+                    var panelHeading = $('<div class="panel-heading">' + result.header + headerErrors + '</div>');
                     var panelBody = $('<div class="panel-body">' + result.body + '</div>');
 
                     panel.append(panelHeading);
@@ -64,8 +83,6 @@ $(function(){
 function toggleAnalysisFunction(input){
     input = $(input);
 
-    console.log(input.val());
-    
     if(input.is(':checked')){
         createAnalysisOptions(input.val());
     } else {


### PR DESCRIPTION
Добавил возможность разворачивать и сворачивать результаты анализа. По умолчанию результаты показываются свернутыми.

### Steps to reproduce
1. Запустить сервер
```
python3 run.py
```

2. Зайти по ссылке `http://127.0.0.1:5001/analysis`

Заполнить форму

- repository - https://github.com/mariadb-corporation/maxscale-jenkins-jobs
- yaml root - maxscale_jobs
- synonyms - {same-node, node-parameters}
- analysis functiions - выбрать все 4
- depends on - maxscale_jobs/include/slave.yaml
- missing call parameters - same-node

Убедиться, что результаты можно сворачивать и разворачивать.